### PR TITLE
Refine dashboard palette for a more elevated aesthetic

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,8 @@
   --ink-300: #6e808e;
   --ink-200: #93a0ab;
   --ink-050: #e3e7ea;
+  --ink-600: #2f4959;
+  --ink-900: #1c2a34;
   --capsule-50: #fff3e4;
   --capsule-100: #ffe7cc;
   --capsule-200: #ffd9a8;
@@ -29,6 +31,7 @@
   --radius-control: 16px;
   --shadow: 0 20px 44px rgba(28, 42, 52, 0.08);
   --shadow-hover: 0 24px 54px rgba(28, 42, 52, 0.1);
+  --glow-soft: 0 16px 40px rgba(28, 42, 52, 0.08);
 }
 
 .app-shell {
@@ -46,6 +49,21 @@
   flex-direction: column;
   gap: 32px;
   background: var(--paper);
+  position: relative;
+}
+
+.sidebar::after {
+  content: '';
+  position: absolute;
+  inset: 24px 0 24px auto;
+  width: 1px;
+  background: linear-gradient(
+    to bottom,
+    rgba(50, 75, 92, 0),
+    rgba(50, 75, 92, 0.12),
+    rgba(50, 75, 92, 0)
+  );
+  pointer-events: none;
 }
 
 .brand {
@@ -124,6 +142,17 @@
   background: rgba(255, 217, 168, 0.7);
 }
 
+.nav-button.is-active {
+  border-color: rgba(255, 217, 168, 0.75);
+  background: rgba(255, 231, 204, 0.8);
+  color: var(--ink-600);
+  box-shadow: inset 0 0 0 1px rgba(255, 217, 168, 0.5);
+}
+
+.nav-button.is-active::before {
+  background: rgba(255, 195, 138, 0.85);
+}
+
 .sidebar-footer {
   margin-top: auto;
 }
@@ -142,7 +171,7 @@
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-  box-shadow: inset 0 0 0 1px rgba(255, 217, 168, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(255, 217, 168, 0.35), var(--glow-soft);
 }
 
 .focus-button:hover,
@@ -157,7 +186,7 @@
   display: flex;
   flex-direction: column;
   gap: 28px;
-  background: rgba(253, 252, 248, 0.92);
+  background: rgba(253, 252, 248, 0.95);
   border-radius: 32px 0 0 32px;
   box-shadow: var(--shadow);
 }
@@ -177,7 +206,7 @@
 .page-title {
   font-size: 32px;
   margin: 0;
-  color: var(--text-primary);
+  color: var(--ink-900);
 }
 
 .icon-button {
@@ -204,9 +233,8 @@
   background: var(--paper);
   border-radius: var(--radius-card);
   padding: 28px;
-  box-shadow: none;
-  border: 1px solid var(--border);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(50, 75, 92, 0.12);
+  box-shadow: var(--glow-soft);
 }
 
 .section {
@@ -231,26 +259,27 @@
 .section-title h2 {
   font-size: 22px;
   margin: 0;
-  color: var(--text-primary);
+  color: var(--ink-600);
 }
 
 .section-action {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  border: 1px solid var(--border-weak);
+  border: 1px solid rgba(50, 75, 92, 0.16);
   border-radius: 999px;
   padding: 10px 16px;
-  background: rgba(253, 252, 248, 0.9);
-  color: var(--ink-400);
+  background: rgba(255, 243, 228, 0.55);
+  color: var(--ink-500);
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .section-action:hover,
 .section-action:focus-visible {
-  background: var(--surface-muted);
-  color: var(--ink-500);
+  background: rgba(255, 217, 168, 0.65);
+  color: var(--ink-600);
+  border-color: rgba(50, 75, 92, 0.24);
 }
 
 .capsule {
@@ -259,8 +288,8 @@
   justify-content: center;
   padding: 6px 16px;
   border-radius: 999px;
-  background: rgba(255, 243, 228, 0.65);
-  color: var(--ink-400);
+  background: rgba(255, 231, 204, 0.75);
+  color: var(--ink-500);
   font-size: 14px;
   font-weight: 600;
 }
@@ -268,7 +297,8 @@
 .capsule.small {
   padding: 4px 12px;
   font-size: 12px;
-  background: rgba(255, 243, 228, 0.45);
+  background: rgba(255, 243, 228, 0.6);
+  color: var(--ink-500);
 }
 
 .grid {
@@ -289,16 +319,34 @@
 }
 
 .highlight {
-  background: rgba(253, 252, 248, 0.86);
-  border-color: var(--border);
+  background: rgba(255, 248, 233, 0.8);
+  border: 1px solid rgba(255, 217, 168, 0.5);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65), var(--glow-soft);
+  position: relative;
+  overflow: hidden;
 }
 
 .highlight:hover,
 .highlight:focus-within {
   transform: translateY(-4px);
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-hover);
+}
+
+.highlight::after {
+  content: '';
+  position: absolute;
+  inset: 18px 18px auto 18px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 195, 138, 0.65);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.highlight > * {
+  position: relative;
+  z-index: 1;
 }
 
 .highlight header p {
@@ -315,10 +363,11 @@
 .tag {
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.8);
-  border: 1px solid var(--border-weak);
-  color: var(--ink-300);
+  background: rgba(255, 231, 204, 0.7);
+  border: 1px solid rgba(255, 217, 168, 0.7);
+  color: var(--ink-600);
   font-size: 12px;
+  font-weight: 500;
 }
 
 .progress {
@@ -331,13 +380,24 @@
 .progress-bar {
   height: 8px;
   border-radius: 999px;
-  background: var(--ink-400);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+  background: rgba(50, 75, 92, 0.1);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--capsule-200);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  transition: width 0.3s ease;
 }
 
 .progress-label {
   font-size: 12px;
-  color: var(--text-secondary);
+  color: var(--ink-400);
+  font-weight: 500;
 }
 
 .timeline {
@@ -354,34 +414,50 @@
   grid-template-columns: auto 1fr;
   gap: 16px;
   align-items: start;
+  position: relative;
+  padding-left: 12px;
+}
+
+.timeline li::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 17px;
+  width: 2px;
+  height: 100%;
+  background: rgba(50, 75, 92, 0.12);
+}
+
+.timeline li:last-child::before {
+  display: none;
 }
 
 .timeline-icon {
   width: 36px;
   height: 36px;
   border-radius: 12px;
-  background: var(--paper);
-  border: 1px solid var(--border);
+  background: rgba(255, 231, 204, 0.8);
+  border: 1px solid rgba(255, 217, 168, 0.7);
   display: grid;
   place-items: center;
-  color: var(--ink-400);
-  box-shadow: 0 6px 14px rgba(28, 42, 52, 0.08);
+  color: var(--ink-600);
+  box-shadow: var(--glow-soft);
 }
 
 .timeline h3 {
   margin: 0 0 6px;
   font-size: 18px;
-  color: var(--text-primary);
+  color: var(--ink-600);
 }
 
 .timeline p {
   margin: 0 0 4px;
-  color: var(--text-secondary);
+  color: var(--ink-400);
 }
 
 .due {
   font-size: 12px;
-  color: var(--text-muted);
+  color: var(--ink-300);
 }
 
 .knowledge-tree {
@@ -390,11 +466,11 @@
 }
 
 .branch {
-  border: 1px solid var(--border);
+  border: 1px solid rgba(50, 75, 92, 0.12);
   border-radius: 20px;
   padding: 20px;
-  background: rgba(253, 252, 248, 0.92);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  background: rgba(255, 252, 248, 0.95);
+  box-shadow: var(--glow-soft);
 }
 
 .branch-header {
@@ -407,6 +483,7 @@
 
 .branch-header h3 {
   margin: 0;
+  color: var(--ink-600);
 }
 
 .capsule-list {
@@ -417,11 +494,29 @@
 
 .branch ul {
   margin: 0;
-  padding-left: 18px;
+  padding-left: 0;
   display: grid;
-  gap: 6px;
+  gap: 8px;
   font-size: 14px;
-  color: var(--ink-400);
+  color: var(--ink-500);
+  list-style: none;
+}
+
+.branch ul li {
+  position: relative;
+  padding-left: 20px;
+}
+
+.branch ul li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 8px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 195, 138, 0.7);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.8);
 }
 
 button:focus-visible,

--- a/src/App.css
+++ b/src/App.css
@@ -1,58 +1,80 @@
 :root {
-  --cream: #f7f2e7;
+  --bg-cream: #f7f2e7;
   --paper: #fdfcf8;
-  --ink: #324b5c;
-  --peach: #ffd9a8;
-  --butter: #fff1cf;
+  --surface-muted: #f5ede1;
+  --ink-500: #324b5c;
+  --ink-400: #4a6171;
+  --ink-300: #6e808e;
+  --ink-200: #93a0ab;
+  --ink-050: #e3e7ea;
+  --capsule-50: #fff3e4;
+  --capsule-100: #ffe7cc;
+  --capsule-200: #ffd9a8;
+  --capsule-300: #ffc78a;
+  --butter-50: #fff8e9;
+  --butter-100: #fff1cf;
+  --text-primary: #2f3a4a;
+  --text-secondary: #4a6171;
+  --text-muted: #93a0ab;
   --success: #37b36b;
+  --success-strong: #218652;
+  --success-soft: #e7f6ee;
   --warning: #f6a723;
   --danger: #e05a59;
+  --border-weak: rgba(50, 75, 92, 0.12);
+  --border: rgba(50, 75, 92, 0.16);
+  --border-strong: rgba(50, 75, 92, 0.24);
+  --focus: rgba(50, 75, 92, 0.36);
   --radius-card: 24px;
-  --radius-control: 14px;
-  --shadow: 0 6px 24px rgba(50, 75, 92, 0.08);
-  --shadow-hover: 0 8px 28px rgba(50, 75, 92, 0.12);
+  --radius-control: 16px;
+  --shadow: 0 20px 44px rgba(28, 42, 52, 0.08);
+  --shadow-hover: 0 24px 54px rgba(28, 42, 52, 0.1);
 }
 
 .app-shell {
   min-height: 100vh;
   display: grid;
   grid-template-columns: 280px 1fr;
-  background: var(--cream);
-  color: var(--ink);
+  background: var(--bg-cream);
+  color: var(--text-primary);
 }
 
 .sidebar {
   padding: 32px 24px;
-  border-right: 1px solid rgba(50, 75, 92, 0.08);
+  border-right: 1px solid var(--border-weak);
   display: flex;
   flex-direction: column;
   gap: 32px;
+  background: var(--paper);
 }
 
 .brand {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  color: var(--ink);
+  color: var(--text-primary);
 }
 
 .logo {
   width: 72px;
   height: 72px;
   border-radius: 20px;
-  background: var(--butter);
+  background: var(--paper);
+  border: 1px solid var(--border);
   display: grid;
   place-items: center;
   font-size: 24px;
-  font-weight: 700;
+  font-weight: 600;
   letter-spacing: 4px;
+  color: var(--ink-400);
+  box-shadow: inset 0 0 0 2px rgba(255, 217, 168, 0.3);
 }
 
 .brand-text {
   font-size: 12px;
   letter-spacing: 0.4em;
   text-transform: uppercase;
-  color: rgba(50, 75, 92, 0.7);
+  color: var(--text-secondary);
 }
 
 .sidebar nav ul {
@@ -70,20 +92,36 @@
   align-items: center;
   gap: 14px;
   padding: 14px 18px;
-  border-radius: 16px;
-  border: 2px solid transparent;
-  background: transparent;
-  color: inherit;
+  border-radius: 18px;
+  border: 1px solid var(--border-weak);
+  background: var(--paper);
+  color: var(--ink-400);
   font-size: 16px;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   cursor: pointer;
+  position: relative;
 }
 
 .nav-button:hover,
 .nav-button:focus-visible {
-  background: var(--paper);
-  border-color: rgba(50, 75, 92, 0.18);
-  box-shadow: var(--shadow);
+  background: var(--surface-muted);
+  color: var(--ink-500);
+  border-color: var(--border);
+}
+
+.nav-button::before {
+  content: '';
+  position: absolute;
+  inset: 8px auto 8px 8px;
+  width: 4px;
+  border-radius: 999px;
+  background: transparent;
+  transition: background 0.2s ease;
+}
+
+.nav-button:hover::before,
+.nav-button:focus-visible::before {
+  background: rgba(255, 217, 168, 0.7);
 }
 
 .sidebar-footer {
@@ -97,19 +135,20 @@
   justify-content: center;
   gap: 12px;
   padding: 16px 20px;
-  background: var(--peach);
-  color: rgba(50, 75, 92, 0.9);
-  border: none;
+  background: var(--paper);
+  color: var(--ink-400);
+  border: 1px solid var(--border);
   border-radius: 999px;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 217, 168, 0.35);
 }
 
 .focus-button:hover,
 .focus-button:focus-visible {
   transform: translateY(-2px);
+  background: var(--surface-muted);
   box-shadow: var(--shadow-hover);
 }
 
@@ -118,6 +157,9 @@
   display: flex;
   flex-direction: column;
   gap: 28px;
+  background: rgba(253, 252, 248, 0.92);
+  border-radius: 32px 0 0 32px;
+  box-shadow: var(--shadow);
 }
 
 .top-bar {
@@ -128,39 +170,43 @@
 
 .subtitle {
   font-size: 14px;
-  color: rgba(50, 75, 92, 0.7);
+  color: var(--text-secondary);
   margin: 0 0 6px;
 }
 
 .page-title {
   font-size: 32px;
   margin: 0;
+  color: var(--text-primary);
 }
 
 .icon-button {
   width: 48px;
   height: 48px;
-  border-radius: 16px;
-  border: 2px solid rgba(50, 75, 92, 0.12);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-weak);
   background: var(--paper);
   display: grid;
   place-items: center;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  color: var(--text-secondary);
 }
 
 .icon-button:hover,
 .icon-button:focus-visible {
-  border-color: rgba(50, 75, 92, 0.3);
-  box-shadow: var(--shadow);
+  border-color: var(--border);
+  background: var(--surface-muted);
+  color: var(--ink-500);
 }
 
 .card {
   background: var(--paper);
   border-radius: var(--radius-card);
   padding: 28px;
-  box-shadow: var(--shadow);
-  border: 2px solid rgba(50, 75, 92, 0.12);
+  box-shadow: none;
+  border: 1px solid var(--border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
 }
 
 .section {
@@ -185,24 +231,26 @@
 .section-title h2 {
   font-size: 22px;
   margin: 0;
+  color: var(--text-primary);
 }
 
 .section-action {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  border: none;
+  border: 1px solid var(--border-weak);
   border-radius: 999px;
   padding: 10px 16px;
-  background: rgba(50, 75, 92, 0.08);
-  color: inherit;
+  background: rgba(253, 252, 248, 0.9);
+  color: var(--ink-400);
   cursor: pointer;
   transition: background 0.2s ease;
 }
 
 .section-action:hover,
 .section-action:focus-visible {
-  background: rgba(50, 75, 92, 0.16);
+  background: var(--surface-muted);
+  color: var(--ink-500);
 }
 
 .capsule {
@@ -211,8 +259,8 @@
   justify-content: center;
   padding: 6px 16px;
   border-radius: 999px;
-  background: var(--peach);
-  color: rgba(50, 75, 92, 0.9);
+  background: rgba(255, 243, 228, 0.65);
+  color: var(--ink-400);
   font-size: 14px;
   font-weight: 600;
 }
@@ -220,6 +268,7 @@
 .capsule.small {
   padding: 4px 12px;
   font-size: 12px;
+  background: rgba(255, 243, 228, 0.45);
 }
 
 .grid {
@@ -239,9 +288,22 @@
   margin: 0 0 4px;
 }
 
+.highlight {
+  background: rgba(253, 252, 248, 0.86);
+  border-color: var(--border);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.7);
+}
+
+.highlight:hover,
+.highlight:focus-within {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow);
+}
+
 .highlight header p {
   margin: 0;
-  color: rgba(50, 75, 92, 0.7);
+  color: var(--text-secondary);
 }
 
 .tag-row {
@@ -253,7 +315,9 @@
 .tag {
   padding: 4px 10px;
   border-radius: 999px;
-  background: rgba(50, 75, 92, 0.08);
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border-weak);
+  color: var(--ink-300);
   font-size: 12px;
 }
 
@@ -267,12 +331,13 @@
 .progress-bar {
   height: 8px;
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--success), rgba(55, 179, 107, 0.3));
+  background: var(--ink-400);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
 .progress-label {
   font-size: 12px;
-  color: rgba(50, 75, 92, 0.7);
+  color: var(--text-secondary);
 }
 
 .timeline {
@@ -295,25 +360,28 @@
   width: 36px;
   height: 36px;
   border-radius: 12px;
-  background: rgba(55, 179, 107, 0.12);
+  background: var(--paper);
+  border: 1px solid var(--border);
   display: grid;
   place-items: center;
-  color: var(--success);
+  color: var(--ink-400);
+  box-shadow: 0 6px 14px rgba(28, 42, 52, 0.08);
 }
 
 .timeline h3 {
   margin: 0 0 6px;
   font-size: 18px;
+  color: var(--text-primary);
 }
 
 .timeline p {
   margin: 0 0 4px;
-  color: rgba(50, 75, 92, 0.7);
+  color: var(--text-secondary);
 }
 
 .due {
   font-size: 12px;
-  color: rgba(50, 75, 92, 0.6);
+  color: var(--text-muted);
 }
 
 .knowledge-tree {
@@ -322,10 +390,11 @@
 }
 
 .branch {
-  border: 1px solid rgba(50, 75, 92, 0.12);
+  border: 1px solid var(--border);
   border-radius: 20px;
   padding: 20px;
-  background: rgba(255, 241, 207, 0.5);
+  background: rgba(253, 252, 248, 0.92);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
 }
 
 .branch-header {
@@ -352,7 +421,14 @@
   display: grid;
   gap: 6px;
   font-size: 14px;
-  color: rgba(50, 75, 92, 0.8);
+  color: var(--ink-400);
+}
+
+button:focus-visible,
+a:focus-visible,
+.capsule:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--focus);
 }
 
 @media (max-width: 1024px) {
@@ -366,6 +442,9 @@
 
   .main-area {
     padding: 32px 24px 48px;
+    background: var(--bg-cream);
+    border-radius: 0;
+    box-shadow: none;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,8 +38,8 @@ const knowledgeTree = [
   },
 ];
 
-const navItems: { label: string; icon: LucideIcon }[] = [
-  { label: '概览', icon: Compass },
+const navItems: { label: string; icon: LucideIcon; isActive?: boolean }[] = [
+  { label: '概览', icon: Compass, isActive: true },
   { label: '课程', icon: BookOpen },
   { label: '任务', icon: ListChecks },
   { label: '资料库', icon: Library },
@@ -57,14 +57,20 @@ function App() {
         </div>
         <nav>
           <ul>
-            {navItems.map((item) => (
-              <li key={item.label}>
-                <button type="button" className="nav-button">
-                  <item.icon aria-hidden="true" />
-                  <span>{item.label}</span>
-                </button>
-              </li>
-            ))}
+            {navItems.map((item) => {
+              const Icon = item.icon;
+              return (
+                <li key={item.label}>
+                  <button
+                    type="button"
+                    className={`nav-button${item.isActive ? ' is-active' : ''}`}
+                  >
+                    <Icon aria-hidden="true" />
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              );
+            })}
           </ul>
         </nav>
         <div className="sidebar-footer">
@@ -112,7 +118,13 @@ function App() {
                   ))}
                 </div>
                 <div className="progress">
-                  <div className="progress-bar" style={{ width: `${item.progress}%` }} />
+                  <div className="progress-bar">
+                    <span
+                      className="progress-fill"
+                      style={{ width: `${item.progress}%` }}
+                      aria-hidden="true"
+                    />
+                  </div>
                   <span className="progress-label">完成度 {item.progress}%</span>
                 </div>
               </article>

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,8 @@ body {
   margin: 0;
   font-family: 'Noto Sans SC', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
     'Segoe UI', sans-serif;
-  background: #f7f2e7;
+  background: var(--bg-cream, #f7f2e7);
+  color: var(--text-primary, #2f3a4a);
 }
 
 * {


### PR DESCRIPTION
## Summary
- introduce a muted surface token and refreshed shadows to support a lighter, airier canvas
- restyle navigation, primary actions, and cards with paper surfaces and subtle peach edging for a more refined feel
- soften highlight, tag, progress, and timeline elements to lean on ink neutrals while keeping peach accents restrained

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87e5a50888332adb5546901e23a72