### PR TITLE
refactor: decouple courses styles for easier merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.544.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@types/react": "^19.1.14",
@@ -1094,6 +1095,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4416,6 +4426,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.14",

--- a/src/App.css
+++ b/src/App.css
@@ -118,6 +118,7 @@
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   cursor: pointer;
   position: relative;
+  text-decoration: none;
 }
 
 .nav-button:hover,
@@ -220,6 +221,7 @@
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
   color: var(--text-secondary);
+  position: relative;
 }
 
 .icon-button:hover,
@@ -227,6 +229,17 @@
   border-color: var(--border);
   background: var(--surface-muted);
   color: var(--ink-500);
+}
+
+.icon-button-indicator {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--warning);
+  top: 10px;
+  right: 10px;
+  box-shadow: 0 0 0 4px rgba(246, 167, 35, 0.2);
 }
 
 .card {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,84 +1,41 @@
 import {
-  ArrowRight,
   Bell,
   BookOpen,
   Calendar,
-  CheckCircle2,
-  ChevronDown,
   Compass,
   Library,
   ListChecks,
   LucideIcon,
-  Plus,
   Settings,
   Timer,
-  X,
 } from 'lucide-react';
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { BrowserRouter, NavLink, Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom';
+import CoursesPage from './pages/Courses';
+import LibraryPage from './pages/Library';
+import OverviewPage from './pages/Overview';
+import SchedulePage from './pages/Schedule';
+import SettingsPage from './pages/Settings';
+import TasksPage from './pages/Tasks';
 import './App.css';
 
-const navItems: { label: string; icon: LucideIcon; isActive?: boolean }[] = [
-  { label: '概览', icon: Compass, isActive: true },
-  { label: '课程', icon: BookOpen },
-  { label: '任务', icon: ListChecks },
-  { label: '资料库', icon: Library },
-  { label: '日程', icon: Calendar },
-  { label: '设置', icon: Settings },
+interface NavItem {
+  label: string;
+  icon: LucideIcon;
+  path: string;
+}
+
+const navItems: NavItem[] = [
+  { label: '概览', icon: Compass, path: '/overview' },
+  { label: '课程', icon: BookOpen, path: '/courses' },
+  { label: '任务', icon: ListChecks, path: '/tasks' },
+  { label: '资料库', icon: Library, path: '/library' },
+  { label: '日程', icon: Calendar, path: '/schedule' },
+  { label: '设置', icon: Settings, path: '/settings' },
 ];
 
-function App() {
-  const [activeNav, setActiveNav] = useState(navItems[0].label);
-  const [todayHighlights, setTodayHighlights] = useState(
-    () =>
-      [
-        { title: 'MUE #0501', subtitle: 'STM32F407 ECH | LWP 调参', tags: ['控制', '嵌入式'], progress: 62 },
-        { title: 'MUE #0502', subtitle: 'BHT70 仿真 | 资料整理', tags: ['仿真', '复盘'], progress: 38 },
-        { title: 'MUE #0903', subtitle: 'Buck 200kHz 设计 Review', tags: ['硬件', '迭代'], progress: 73 },
-      ] as {
-        title: string;
-        subtitle: string;
-        tags: string[];
-        progress: number;
-      }[],
-  );
-  const [highlightDraft, setHighlightDraft] = useState({
-    title: '',
-    subtitle: '',
-    tags: '',
-    progress: 50,
-  });
-  const [isHighlightFormOpen, setHighlightFormOpen] = useState(false);
-  const [reviewList, setReviewList] = useState(
-    () =>
-      [
-        { title: '待复习 · 信号与系统', detail: '章节 3：卷积与响应', due: '今日 21:30', done: false },
-        { title: 'DoD 检查点', detail: 'MUE #0501 仿真记录上传', due: '明日 09:00', done: false },
-        { title: '资源再梳理', detail: 'Buck 设计资料包整理', due: '周四 18:00', done: false },
-      ] as { title: string; detail: string; due: string; done: boolean }[],
-  );
-  const [reviewDraft, setReviewDraft] = useState({ title: '', detail: '', due: '' });
-  const [knowledgeTree, setKnowledgeTree] = useState(
-    () =>
-      [
-        {
-          title: '数模协同',
-          capsules: ['建模', '仿真', '调参'],
-          items: ['MUE #0501 波形对照', 'MATLAB 优化脚本', '控制器参数表'],
-        },
-        {
-          title: '电源设计',
-          capsules: ['Buck', '磁性件', '效率'],
-          items: ['损耗模型 V2', 'Spice 数据库', '实验记录 0903'],
-        },
-      ] as { title: string; capsules: string[]; items: string[] }[],
-  );
-  const [knowledgeDraft, setKnowledgeDraft] = useState({
-    branchChoice: '数模协同',
-    customBranch: '',
-    item: '',
-  });
-  const [isKnowledgeFormOpen, setKnowledgeFormOpen] = useState(false);
-  const [isReviewFormOpen, setReviewFormOpen] = useState(false);
+function DashboardLayout() {
+  const location = useLocation();
   const [focusCountdown, setFocusCountdown] = useState<number | null>(null);
   const [isFocusRunning, setFocusRunning] = useState(false);
   const [now, setNow] = useState(new Date());
@@ -116,120 +73,6 @@ function App() {
     return `${minutes}:${seconds}`;
   }, [focusCountdown, isFocusRunning]);
 
-  const handleHighlightChange = (field: keyof typeof highlightDraft, value: string | number) => {
-    setHighlightDraft((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleReviewChange = (field: keyof typeof reviewDraft, value: string) => {
-    setReviewDraft((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleKnowledgeChange = (field: keyof typeof knowledgeDraft, value: string) => {
-    setKnowledgeDraft((prev) => ({ ...prev, [field]: value }));
-  };
-
-  const handleHighlightSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!highlightDraft.title.trim()) {
-      return;
-    }
-    setTodayHighlights((prev) => [
-      {
-        title: highlightDraft.title.trim(),
-        subtitle: highlightDraft.subtitle.trim(),
-        tags: highlightDraft.tags
-          .split(',')
-          .map((tag) => tag.trim())
-          .filter(Boolean),
-        progress: Number(highlightDraft.progress),
-      },
-      ...prev,
-    ]);
-    setHighlightDraft({ title: '', subtitle: '', tags: '', progress: 50 });
-    setHighlightFormOpen(false);
-  };
-
-  const handleReviewSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!reviewDraft.title.trim() || !reviewDraft.due.trim()) {
-      return;
-    }
-    setReviewList((prev) => [
-      {
-        title: reviewDraft.title.trim(),
-        detail: reviewDraft.detail.trim(),
-        due: reviewDraft.due.trim(),
-        done: false,
-      },
-      ...prev,
-    ]);
-    setReviewDraft({ title: '', detail: '', due: '' });
-    setReviewFormOpen(false);
-  };
-
-  const handleKnowledgeSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const branchName =
-      knowledgeDraft.branchChoice === '__custom'
-        ? knowledgeDraft.customBranch.trim()
-        : knowledgeDraft.branchChoice;
-    if (!knowledgeDraft.item.trim() || !branchName) {
-      return;
-    }
-    setKnowledgeTree((prev) => {
-      const branchIndex = prev.findIndex((branch) => branch.title === branchName);
-      if (branchIndex === -1) {
-        return [
-          ...prev,
-          {
-            title: branchName,
-            capsules: [],
-            items: [knowledgeDraft.item.trim()],
-          },
-        ];
-      }
-      const clone = [...prev];
-      clone[branchIndex] = {
-        ...clone[branchIndex],
-        items: [knowledgeDraft.item.trim(), ...clone[branchIndex].items],
-      };
-      return clone;
-    });
-    setKnowledgeDraft((prev) => ({
-      branchChoice: prev.branchChoice === '__custom' ? branchName : prev.branchChoice,
-      customBranch: '',
-      item: '',
-    }));
-    setKnowledgeFormOpen(false);
-  };
-
-  const toggleReviewDone = (title: string) => {
-    setReviewList((prev) =>
-      prev.map((item) =>
-        item.title === title
-          ? {
-              ...item,
-              done: !item.done,
-            }
-          : item,
-      ),
-    );
-  };
-
-  const handleHighlightProgressChange = (
-    title: string,
-    event: ChangeEvent<HTMLInputElement>,
-  ) => {
-    const value = Number(event.target.value);
-    setTodayHighlights((prev) =>
-      prev.map((item) => (item.title === title ? { ...item, progress: value } : item)),
-    );
-  };
-
-  const handleRemoveHighlight = (title: string) => {
-    setTodayHighlights((prev) => prev.filter((item) => item.title !== title));
-  };
-
   const handleStartFocus = () => {
     if (isFocusRunning) {
       setFocusRunning(false);
@@ -250,6 +93,11 @@ function App() {
     }).format(now);
   }, [now]);
 
+  const activeItem = useMemo(
+    () => navItems.find((item) => location.pathname.startsWith(item.path)) ?? navItems[0],
+    [location.pathname],
+  );
+
   return (
     <div className="app-shell">
       <aside className="sidebar" aria-label="主导航">
@@ -263,14 +111,10 @@ function App() {
               const Icon = item.icon;
               return (
                 <li key={item.label}>
-                  <button
-                    type="button"
-                    className={`nav-button${activeNav === item.label ? ' is-active' : ''}`}
-                    onClick={() => setActiveNav(item.label)}
-                  >
+                  <NavLink to={item.path} className={({ isActive }) => `nav-button${isActive ? ' is-active' : ''}`}>
                     <Icon aria-hidden="true" />
                     <span>{item.label}</span>
-                  </button>
+                  </NavLink>
                 </li>
               );
             })}
@@ -288,319 +132,35 @@ function App() {
         <header className="top-bar">
           <div>
             <p className="subtitle">{formattedDate}</p>
-            <h1 className="page-title">技术小天地 Dashboard</h1>
+            <h1 className="page-title">技术小天地 Dashboard · {activeItem.label}</h1>
           </div>
           <button type="button" className="icon-button" aria-label="查看提醒">
             <Bell aria-hidden="true" />
+            <span className="icon-button-indicator" aria-hidden="true" />
           </button>
         </header>
-
-        <section className="card section">
-          <div className="section-header">
-            <div className="section-title">
-              <span className="capsule">今日三件事</span>
-              <h2>今日目标推进</h2>
-            </div>
-            <div className="section-actions">
-              <button type="button" className="section-action" onClick={() => setHighlightFormOpen((prev) => !prev)}>
-                {isHighlightFormOpen ? '收起表单' : '添加目标'}
-                {isHighlightFormOpen ? <X aria-hidden="true" /> : <Plus aria-hidden="true" />}
-              </button>
-              <button type="button" className="section-action subtle">
-                查看计划
-                <ArrowRight aria-hidden="true" />
-              </button>
-            </div>
-          </div>
-          {isHighlightFormOpen ? (
-            <form className="inline-form" onSubmit={handleHighlightSubmit}>
-              <div className="form-row">
-                <label className="field">
-                  <span>目标标题</span>
-                  <input
-                    type="text"
-                    value={highlightDraft.title}
-                    onChange={(event) => handleHighlightChange('title', event.target.value)}
-                    placeholder="例如：MUE #0510"
-                    required
-                  />
-                </label>
-                <label className="field">
-                  <span>关联标签</span>
-                  <input
-                    type="text"
-                    value={highlightDraft.tags}
-                    onChange={(event) => handleHighlightChange('tags', event.target.value)}
-                    placeholder="逗号分隔，例如：硬件, 仿真"
-                  />
-                </label>
-              </div>
-              <div className="form-row">
-                <label className="field">
-                  <span>目标摘要</span>
-                  <input
-                    type="text"
-                    value={highlightDraft.subtitle}
-                    onChange={(event) => handleHighlightChange('subtitle', event.target.value)}
-                    placeholder="一句话描述当前阶段"
-                  />
-                </label>
-                <label className="field">
-                  <span>完成度</span>
-                  <input
-                    type="range"
-                    min={0}
-                    max={100}
-                    value={highlightDraft.progress}
-                    onChange={(event) => handleHighlightChange('progress', Number(event.target.value))}
-                  />
-                  <span className="range-value">{highlightDraft.progress}%</span>
-                </label>
-              </div>
-              <footer className="form-footer">
-                <button type="submit" className="primary">
-                  收录到今日目标
-                </button>
-              </footer>
-            </form>
-          ) : null}
-          <div className="grid three">
-            {todayHighlights.map((item) => (
-              <article className="card highlight" key={item.title}>
-                <header>
-                  <h3>{item.title}</h3>
-                  <p>{item.subtitle}</p>
-                </header>
-                <div className="tag-row">
-                  {item.tags.map((tag) => (
-                    <span key={tag} className="tag">
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-                <div className="progress">
-                  <div className="progress-bar">
-                    <span
-                      className="progress-fill"
-                      style={{ width: `${item.progress}%` }}
-                      aria-hidden="true"
-                    />
-                  </div>
-                  <span className="progress-label">完成度 {item.progress}%</span>
-                  <input
-                    className="progress-slider"
-                    type="range"
-                    min={0}
-                    max={100}
-                    value={item.progress}
-                    onChange={(event) => handleHighlightProgressChange(item.title, event)}
-                    aria-label={`更新 ${item.title} 的完成度`}
-                  />
-                </div>
-                <div className="card-actions">
-                  <button
-                    type="button"
-                    className="chip-button"
-                    onClick={() =>
-                      setTodayHighlights((prev) =>
-                        prev.map((highlight) =>
-                          highlight.title === item.title
-                            ? { ...highlight, progress: 100 }
-                            : highlight,
-                        ),
-                      )
-                    }
-                  >
-                    <CheckCircle2 aria-hidden="true" /> 完成
-                  </button>
-                  <button
-                    type="button"
-                    className="chip-button danger"
-                    onClick={() => handleRemoveHighlight(item.title)}
-                  >
-                    <X aria-hidden="true" /> 移除
-                  </button>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <div className="grid two">
-          <section className="card section">
-            <div className="section-header">
-              <div className="section-title">
-                <span className="capsule">复习进度</span>
-                <h2>待复习 / DoD</h2>
-              </div>
-              <div className="section-actions">
-                <button type="button" className="section-action" onClick={() => setReviewFormOpen((prev) => !prev)}>
-                  {isReviewFormOpen ? '收起表单' : '添加提醒'}
-                  {isReviewFormOpen ? <X aria-hidden="true" /> : <Plus aria-hidden="true" />}
-                </button>
-                <button type="button" className="section-action subtle">
-                  打印复盘
-                  <ArrowRight aria-hidden="true" />
-                </button>
-              </div>
-            </div>
-            {isReviewFormOpen ? (
-              <form className="inline-form" onSubmit={handleReviewSubmit}>
-                <div className="form-row">
-                  <label className="field">
-                    <span>复习标题</span>
-                    <input
-                      type="text"
-                      value={reviewDraft.title}
-                      onChange={(event) => handleReviewChange('title', event.target.value)}
-                      placeholder="例如：增益稳定性复盘"
-                      required
-                    />
-                  </label>
-                  <label className="field">
-                    <span>截止提醒</span>
-                    <input
-                      type="text"
-                      value={reviewDraft.due}
-                      onChange={(event) => handleReviewChange('due', event.target.value)}
-                      placeholder="例如：周五 18:00"
-                      required
-                    />
-                  </label>
-                </div>
-                <label className="field">
-                  <span>补充说明</span>
-                  <input
-                    type="text"
-                    value={reviewDraft.detail}
-                    onChange={(event) => handleReviewChange('detail', event.target.value)}
-                    placeholder="可选：章节、文件名等"
-                  />
-                </label>
-                <footer className="form-footer">
-                  <button type="submit" className="primary">
-                    添加至复习清单
-                  </button>
-                </footer>
-              </form>
-            ) : null}
-            <ul className="timeline">
-              {reviewList.map((item) => (
-                <li key={item.title}>
-                  <div className="timeline-icon">
-                    <CheckCircle2 aria-hidden="true" />
-                  </div>
-                  <div>
-                    <div className="timeline-header">
-                      <h3 className={item.done ? 'is-done' : undefined}>{item.title}</h3>
-                      <button
-                        type="button"
-                        className={`chip-button${item.done ? ' primary' : ''}`}
-                        onClick={() => toggleReviewDone(item.title)}
-                      >
-                        {item.done ? '已完成' : '标记完成'}
-                      </button>
-                    </div>
-                    <p className={item.done ? 'is-done' : undefined}>{item.detail}</p>
-                    <span className="due">{item.due}</span>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          <section className="card section">
-            <div className="section-header">
-              <div className="section-title">
-                <span className="capsule">知识树</span>
-                <h2>知识积木树</h2>
-              </div>
-              <div className="section-actions">
-                <button type="button" className="section-action" onClick={() => setKnowledgeFormOpen((prev) => !prev)}>
-                  {isKnowledgeFormOpen ? '收起表单' : '新增素材'}
-                  {isKnowledgeFormOpen ? <X aria-hidden="true" /> : <Plus aria-hidden="true" />}
-                </button>
-                <button type="button" className="section-action subtle">
-                  管理资源
-                  <ArrowRight aria-hidden="true" />
-                </button>
-              </div>
-            </div>
-            {isKnowledgeFormOpen ? (
-              <form className="inline-form" onSubmit={handleKnowledgeSubmit}>
-                <div className="form-row">
-                  <label className="field select">
-                    <span>选择或创建分支</span>
-                    <div className="select-control">
-                      <select
-                        value={knowledgeDraft.branchChoice}
-                        onChange={(event) => handleKnowledgeChange('branchChoice', event.target.value)}
-                      >
-                        {knowledgeTree.map((branch) => (
-                          <option value={branch.title} key={branch.title}>
-                            {branch.title}
-                          </option>
-                        ))}
-                        <option value="__custom">自定义分支…</option>
-                      </select>
-                      <ChevronDown aria-hidden="true" />
-                    </div>
-                  </label>
-                  {knowledgeDraft.branchChoice === '__custom' ? (
-                    <label className="field">
-                      <span>新分支名称</span>
-                      <input
-                        type="text"
-                        value={knowledgeDraft.customBranch}
-                        onChange={(event) => handleKnowledgeChange('customBranch', event.target.value)}
-                        placeholder="例如：系统工程"
-                        required
-                      />
-                    </label>
-                  ) : null}
-                </div>
-                <label className="field">
-                  <span>素材条目</span>
-                  <input
-                    type="text"
-                    value={knowledgeDraft.item}
-                    onChange={(event) => handleKnowledgeChange('item', event.target.value)}
-                    placeholder="输入你要记录的知识资产"
-                    required
-                  />
-                </label>
-                <footer className="form-footer">
-                  <button type="submit" className="primary">
-                    收录到知识树
-                  </button>
-                </footer>
-              </form>
-            ) : null}
-            <div className="knowledge-tree">
-              {knowledgeTree.map((branch) => (
-                <div key={branch.title} className="branch">
-                  <div className="branch-header">
-                    <h3>{branch.title}</h3>
-                    <div className="capsule-list">
-                      {branch.capsules.map((capsule) => (
-                        <span key={capsule} className="capsule small">
-                          {capsule}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                  <ul>
-                    {branch.items.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </section>
-        </div>
+        <Outlet />
       </main>
     </div>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<DashboardLayout />}>
+          <Route index element={<Navigate to="/overview" replace />} />
+          <Route path="overview" element={<OverviewPage />} />
+          <Route path="courses" element={<CoursesPage />} />
+          <Route path="tasks" element={<TasksPage />} />
+          <Route path="library" element={<LibraryPage />} />
+          <Route path="schedule" element={<SchedulePage />} />
+          <Route path="settings" element={<SettingsPage />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/overview" replace />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/src/components/UnderConstruction.css
+++ b/src/components/UnderConstruction.css
@@ -1,0 +1,54 @@
+.under-construction {
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+}
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 24px;
+  background: linear-gradient(135deg, rgba(255, 231, 204, 0.35), rgba(247, 242, 231, 0.6));
+  border-radius: var(--radius-card);
+  border: 1px dashed rgba(50, 75, 92, 0.18);
+  color: var(--text-secondary);
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 17px;
+  color: var(--ink-500);
+}
+
+.empty-state-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 8px;
+  color: var(--ink-400);
+}
+
+.empty-state-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--ink-300);
+  font-size: 14px;
+}
+
+.empty-state.compact {
+  padding: 24px;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+}
+
+.empty-state.compact svg {
+  width: 36px;
+  height: 36px;
+  color: rgba(255, 195, 138, 0.9);
+}

--- a/src/components/UnderConstruction.tsx
+++ b/src/components/UnderConstruction.tsx
@@ -1,0 +1,34 @@
+import { ArrowRight } from 'lucide-react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import './UnderConstruction.css';
+
+interface UnderConstructionProps {
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}
+
+function UnderConstruction({ title, description, actions, children }: PropsWithChildren<UnderConstructionProps>) {
+  return (
+    <section className="card section under-construction">
+      <div className="section-header">
+        <div className="section-title">
+          <span className="capsule">建设中</span>
+          <h2>{title}</h2>
+        </div>
+        {actions ? <div className="section-actions">{actions}</div> : null}
+      </div>
+      <div className="empty-state">
+        <p>{description}</p>
+        {children}
+        <div className="empty-state-footer">
+          <ArrowRight aria-hidden="true" />
+          <span>功能规划已在概览中列出，敬请期待</span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default UnderConstruction;

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -1,0 +1,1 @@
+export { default } from './courses/CoursesPage';

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,0 +1,18 @@
+import UnderConstruction from '../components/UnderConstruction';
+
+function LibraryPage() {
+  return (
+    <UnderConstruction
+      title="资料库模块"
+      description="统一管理知识素材，支持分支树浏览、搜索与内容编辑，形成技术资产沉淀。"
+    >
+      <ul className="empty-state-list">
+        <li>树状分支导航与列表视图组合，快速定位资料</li>
+        <li>新增 / 编辑 / 删除知识条目，并支持批量导入</li>
+        <li>与概览知识树同步，保持单一数据源</li>
+      </ul>
+    </UnderConstruction>
+  );
+}
+
+export default LibraryPage;

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,0 +1,477 @@
+import {
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  Plus,
+  X,
+} from 'lucide-react';
+import { ChangeEvent, FormEvent, useState } from 'react';
+
+function OverviewPage() {
+  const [todayHighlights, setTodayHighlights] = useState(() =>
+    [
+      { title: 'MUE #0501', subtitle: 'STM32F407 ECH | LWP 调参', tags: ['控制', '嵌入式'], progress: 62 },
+      { title: 'MUE #0502', subtitle: 'BHT70 仿真 | 资料整理', tags: ['仿真', '复盘'], progress: 38 },
+      { title: 'MUE #0903', subtitle: 'Buck 200kHz 设计 Review', tags: ['硬件', '迭代'], progress: 73 },
+    ] as {
+      title: string;
+      subtitle: string;
+      tags: string[];
+      progress: number;
+    }[],
+  );
+  const [highlightDraft, setHighlightDraft] = useState({
+    title: '',
+    subtitle: '',
+    tags: '',
+    progress: 50,
+  });
+  const [isHighlightFormOpen, setHighlightFormOpen] = useState(false);
+  const [reviewList, setReviewList] = useState(() =>
+    [
+      { title: '待复习 · 信号与系统', detail: '章节 3：卷积与响应', due: '今日 21:30', done: false },
+      { title: 'DoD 检查点', detail: 'MUE #0501 仿真记录上传', due: '明日 09:00', done: false },
+      { title: '资源再梳理', detail: 'Buck 设计资料包整理', due: '周四 18:00', done: false },
+    ] as { title: string; detail: string; due: string; done: boolean }[],
+  );
+  const [reviewDraft, setReviewDraft] = useState({ title: '', detail: '', due: '' });
+  const [knowledgeTree, setKnowledgeTree] = useState(() =>
+    [
+      {
+        title: '数模协同',
+        capsules: ['建模', '仿真', '调参'],
+        items: ['MUE #0501 波形对照', 'MATLAB 优化脚本', '控制器参数表'],
+      },
+      {
+        title: '电源设计',
+        capsules: ['Buck', '磁性件', '效率'],
+        items: ['损耗模型 V2', 'Spice 数据库', '实验记录 0903'],
+      },
+    ] as { title: string; capsules: string[]; items: string[] }[],
+  );
+  const [knowledgeDraft, setKnowledgeDraft] = useState({
+    branchChoice: '数模协同',
+    customBranch: '',
+    item: '',
+  });
+  const [isKnowledgeFormOpen, setKnowledgeFormOpen] = useState(false);
+  const [isReviewFormOpen, setReviewFormOpen] = useState(false);
+
+  const handleHighlightChange = (field: keyof typeof highlightDraft, value: string | number) => {
+    setHighlightDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleReviewChange = (field: keyof typeof reviewDraft, value: string) => {
+    setReviewDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleKnowledgeChange = (field: keyof typeof knowledgeDraft, value: string) => {
+    setKnowledgeDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleHighlightSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!highlightDraft.title.trim()) {
+      return;
+    }
+    setTodayHighlights((prev) => [
+      {
+        title: highlightDraft.title.trim(),
+        subtitle: highlightDraft.subtitle.trim(),
+        tags: highlightDraft.tags
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+        progress: Number(highlightDraft.progress),
+      },
+      ...prev,
+    ]);
+    setHighlightDraft({ title: '', subtitle: '', tags: '', progress: 50 });
+    setHighlightFormOpen(false);
+  };
+
+  const handleReviewSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!reviewDraft.title.trim() || !reviewDraft.due.trim()) {
+      return;
+    }
+    setReviewList((prev) => [
+      {
+        title: reviewDraft.title.trim(),
+        detail: reviewDraft.detail.trim(),
+        due: reviewDraft.due.trim(),
+        done: false,
+      },
+      ...prev,
+    ]);
+    setReviewDraft({ title: '', detail: '', due: '' });
+    setReviewFormOpen(false);
+  };
+
+  const handleKnowledgeSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const branchName =
+      knowledgeDraft.branchChoice === '__custom'
+        ? knowledgeDraft.customBranch.trim()
+        : knowledgeDraft.branchChoice;
+    if (!knowledgeDraft.item.trim() || !branchName) {
+      return;
+    }
+    setKnowledgeTree((prev) => {
+      const branchIndex = prev.findIndex((branch) => branch.title === branchName);
+      if (branchIndex === -1) {
+        return [
+          ...prev,
+          {
+            title: branchName,
+            capsules: [],
+            items: [knowledgeDraft.item.trim()],
+          },
+        ];
+      }
+      const clone = [...prev];
+      clone[branchIndex] = {
+        ...clone[branchIndex],
+        items: [knowledgeDraft.item.trim(), ...clone[branchIndex].items],
+      };
+      return clone;
+    });
+    setKnowledgeDraft((prev) => ({
+      branchChoice: prev.branchChoice === '__custom' ? branchName : prev.branchChoice,
+      customBranch: '',
+      item: '',
+    }));
+    setKnowledgeFormOpen(false);
+  };
+
+  const toggleReviewDone = (title: string) => {
+    setReviewList((prev) =>
+      prev.map((item) =>
+        item.title === title
+          ? {
+              ...item,
+              done: !item.done,
+            }
+          : item,
+      ),
+    );
+  };
+
+  const handleHighlightProgressChange = (title: string, event: ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    setTodayHighlights((prev) => prev.map((item) => (item.title === title ? { ...item, progress: value } : item)));
+  };
+
+  const handleRemoveHighlight = (title: string) => {
+    setTodayHighlights((prev) => prev.filter((item) => item.title !== title));
+  };
+
+  return (
+    <>
+      <section className="card section">
+        <div className="section-header">
+          <div className="section-title">
+            <span className="capsule">今日三件事</span>
+            <h2>今日目标推进</h2>
+          </div>
+          <div className="section-actions">
+            <button type="button" className="section-action" onClick={() => setHighlightFormOpen((prev) => !prev)}>
+              {isHighlightFormOpen ? '收起表单' : '添加目标'}
+              {isHighlightFormOpen ? <X aria-hidden="true" /> : <Plus aria-hidden="true" />}
+            </button>
+            <button type="button" className="section-action subtle">
+              查看计划
+              <ArrowRight aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+        {isHighlightFormOpen ? (
+          <form className="inline-form" onSubmit={handleHighlightSubmit}>
+            <div className="form-row">
+              <label className="field">
+                <span>目标标题</span>
+                <input
+                  type="text"
+                  value={highlightDraft.title}
+                  onChange={(event) => handleHighlightChange('title', event.target.value)}
+                  placeholder="例如：MUE #0510"
+                  required
+                />
+              </label>
+              <label className="field">
+                <span>关联标签</span>
+                <input
+                  type="text"
+                  value={highlightDraft.tags}
+                  onChange={(event) => handleHighlightChange('tags', event.target.value)}
+                  placeholder="逗号分隔，例如：硬件, 仿真"
+                />
+              </label>
+            </div>
+            <div className="form-row">
+              <label className="field">
+                <span>目标摘要</span>
+                <input
+                  type="text"
+                  value={highlightDraft.subtitle}
+                  onChange={(event) => handleHighlightChange('subtitle', event.target.value)}
+                  placeholder="一句话描述当前阶段"
+                />
+              </label>
+              <label className="field">
+                <span>完成度</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={highlightDraft.progress}
+                  onChange={(event) => handleHighlightChange('progress', Number(event.target.value))}
+                />
+                <span className="range-value">{highlightDraft.progress}%</span>
+              </label>
+            </div>
+            <footer className="form-footer">
+              <button type="submit" className="primary">
+                收录到今日目标
+              </button>
+            </footer>
+          </form>
+        ) : null}
+        <div className="grid three">
+          {todayHighlights.map((item) => (
+            <article className="card highlight" key={item.title}>
+              <header>
+                <h3>{item.title}</h3>
+                <p>{item.subtitle}</p>
+              </header>
+              <div className="tag-row">
+                {item.tags.map((tag) => (
+                  <span key={tag} className="tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <div className="progress">
+                <div className="progress-bar">
+                  <span className="progress-fill" style={{ width: `${item.progress}%` }} aria-hidden="true" />
+                </div>
+                <span className="progress-label">完成度 {item.progress}%</span>
+                <input
+                  className="progress-slider"
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={item.progress}
+                  onChange={(event) => handleHighlightProgressChange(item.title, event)}
+                  aria-label={`更新 ${item.title} 的完成度`}
+                />
+              </div>
+              <div className="card-actions">
+                <button
+                  type="button"
+                  className="chip-button"
+                  onClick={() =>
+                    setTodayHighlights((prev) =>
+                      prev.map((highlight) =>
+                        highlight.title === item.title ? { ...highlight, progress: 100 } : highlight,
+                      ),
+                    )
+                  }
+                >
+                  <CheckCircle2 aria-hidden="true" /> 完成
+                </button>
+                <button
+                  type="button"
+                  className="chip-button danger"
+                  onClick={() => handleRemoveHighlight(item.title)}
+                >
+                  <X aria-hidden="true" /> 移除
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <div className="grid two">
+        <section className="card section">
+          <div className="section-header">
+            <div className="section-title">
+              <span className="capsule">复习进度</span>
+              <h2>待复习 / DoD</h2>
+            </div>
+            <div className="section-actions">
+              <button type="button" className="section-action" onClick={() => setReviewFormOpen((prev) => !prev)}>
+                {isReviewFormOpen ? '收起表单' : '添加提醒'}
+                {isReviewFormOpen ? <X aria-hidden="true" /> : <Plus aria-hidden="true" />}
+              </button>
+              <button type="button" className="section-action subtle">
+                打印复盘
+                <ArrowRight aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+          {isReviewFormOpen ? (
+            <form className="inline-form" onSubmit={handleReviewSubmit}>
+              <div className="form-row">
+                <label className="field">
+                  <span>复习标题</span>
+                  <input
+                    type="text"
+                    value={reviewDraft.title}
+                    onChange={(event) => handleReviewChange('title', event.target.value)}
+                    placeholder="例如：增益稳定性复盘"
+                    required
+                  />
+                </label>
+                <label className="field">
+                  <span>截止提醒</span>
+                  <input
+                    type="text"
+                    value={reviewDraft.due}
+                    onChange={(event) => handleReviewChange('due', event.target.value)}
+                    placeholder="例如：周五 18:00"
+                    required
+                  />
+                </label>
+              </div>
+              <label className="field">
+                <span>补充说明</span>
+                <input
+                  type="text"
+                  value={reviewDraft.detail}
+                  onChange={(event) => handleReviewChange('detail', event.target.value)}
+                  placeholder="可选：章节、文件名等"
+                />
+              </label>
+              <footer className="form-footer">
+                <button type="submit" className="primary">
+                  添加至复习清单
+                </button>
+              </footer>
+            </form>
+          ) : null}
+          <ul className="timeline">
+            {reviewList.map((item) => (
+              <li key={item.title}>
+                <div className="timeline-icon">
+                  <CheckCircle2 aria-hidden="true" />
+                </div>
+                <div>
+                  <div className="timeline-header">
+                    <h3 className={item.done ? 'is-done' : undefined}>{item.title}</h3>
+                    <button
+                      type="button"
+                      className={`chip-button${item.done ? ' primary' : ''}`}
+                      onClick={() => toggleReviewDone(item.title)}
+                    >
+                      {item.done ? '已完成' : '标记完成'}
+                    </button>
+                  </div>
+                  <p className={item.done ? 'is-done' : undefined}>{item.detail}</p>
+                  <span className="due">{item.due}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="card section">
+          <div className="section-header">
+            <div className="section-title">
+              <span className="capsule">知识树</span>
+              <h2>知识积木树</h2>
+            </div>
+            <div className="section-actions">
+              <button
+                type="button"
+                className="section-action"
+                onClick={() => setKnowledgeFormOpen((prev) => !prev)}
+              >
+                {isKnowledgeFormOpen ? '收起表单' : '新增素材'}
+                {isKnowledgeFormOpen ? <X aria-hidden="true" /> : <Plus aria-hidden="true" />}
+              </button>
+              <button type="button" className="section-action subtle">
+                管理资源
+                <ArrowRight aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+          {isKnowledgeFormOpen ? (
+            <form className="inline-form" onSubmit={handleKnowledgeSubmit}>
+              <div className="form-row">
+                <label className="field select">
+                  <span>选择或创建分支</span>
+                  <div className="select-control">
+                    <select
+                      value={knowledgeDraft.branchChoice}
+                      onChange={(event) => handleKnowledgeChange('branchChoice', event.target.value)}
+                    >
+                      {knowledgeTree.map((branch) => (
+                        <option value={branch.title} key={branch.title}>
+                          {branch.title}
+                        </option>
+                      ))}
+                      <option value="__custom">自定义分支…</option>
+                    </select>
+                    <ChevronDown aria-hidden="true" />
+                  </div>
+                </label>
+                {knowledgeDraft.branchChoice === '__custom' ? (
+                  <label className="field">
+                    <span>新分支名称</span>
+                    <input
+                      type="text"
+                      value={knowledgeDraft.customBranch}
+                      onChange={(event) => handleKnowledgeChange('customBranch', event.target.value)}
+                      placeholder="例如：系统工程"
+                      required
+                    />
+                  </label>
+                ) : null}
+              </div>
+              <label className="field">
+                <span>素材条目</span>
+                <input
+                  type="text"
+                  value={knowledgeDraft.item}
+                  onChange={(event) => handleKnowledgeChange('item', event.target.value)}
+                  placeholder="输入你要记录的知识资产"
+                  required
+                />
+              </label>
+              <footer className="form-footer">
+                <button type="submit" className="primary">
+                  收录到知识树
+                </button>
+              </footer>
+            </form>
+          ) : null}
+          <div className="knowledge-tree">
+            {knowledgeTree.map((branch) => (
+              <div key={branch.title} className="branch">
+                <div className="branch-header">
+                  <h3>{branch.title}</h3>
+                  <div className="capsule-list">
+                    {branch.capsules.map((capsule) => (
+                      <span key={capsule} className="capsule small">
+                        {capsule}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <ul>
+                  {branch.items.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </>
+  );
+}
+
+export default OverviewPage;

--- a/src/pages/Schedule.tsx
+++ b/src/pages/Schedule.tsx
@@ -1,0 +1,18 @@
+import UnderConstruction from '../components/UnderConstruction';
+
+function SchedulePage() {
+  return (
+    <UnderConstruction
+      title="日程模块"
+      description="将在此呈现周/月视图日历，集中管理任务截止与学习安排，并提供提醒。"
+    >
+      <ul className="empty-state-list">
+        <li>日历视图标注任务、课程与提醒事件</li>
+        <li>新增 / 编辑日程，并支持提醒设置</li>
+        <li>任务与课程的关键节点自动同步到日历</li>
+      </ul>
+    </UnderConstruction>
+  );
+}
+
+export default SchedulePage;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,18 @@
+import UnderConstruction from '../components/UnderConstruction';
+
+function SettingsPage() {
+  return (
+    <UnderConstruction
+      title="设置模块"
+      description="将在这里配置账户偏好、主题模式和通知策略，支持多端个性化。"
+    >
+      <ul className="empty-state-list">
+        <li>基础信息与团队配置，预留多用户扩展接口</li>
+        <li>主题切换、字体与布局调整等个性化选项</li>
+        <li>通知、提醒与数据同步的偏好设定</li>
+      </ul>
+    </UnderConstruction>
+  );
+}
+
+export default SettingsPage;

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,0 +1,18 @@
+import UnderConstruction from '../components/UnderConstruction';
+
+function TasksPage() {
+  return (
+    <UnderConstruction
+      title="任务模块"
+      description="集中管理项目任务与待办，将支持筛选、编辑以及与“今日三件事”联动。"
+    >
+      <ul className="empty-state-list">
+        <li>任务列表视图与标签分类，支持排序筛选</li>
+        <li>新增 / 编辑 / 删除任务，追踪截止时间与优先级</li>
+        <li>一键标记为今日重点，与概览模块同步</li>
+      </ul>
+    </UnderConstruction>
+  );
+}
+
+export default TasksPage;

--- a/src/pages/courses/CoursesPage.tsx
+++ b/src/pages/courses/CoursesPage.tsx
@@ -1,0 +1,383 @@
+import { BookOpenCheck, CalendarDays, CheckCircle2, PlayCircle, Sparkles, Tag } from 'lucide-react';
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
+
+import './courses.css';
+
+interface CourseOutlineItem {
+  title: string;
+  duration: string;
+  completed: boolean;
+}
+
+interface CourseResource {
+  title: string;
+  type: string;
+}
+
+interface CourseTask {
+  title: string;
+  due: string;
+  type: 'task' | 'review';
+}
+
+interface Course {
+  id: string;
+  title: string;
+  subtitle: string;
+  instructor: string;
+  tags: string[];
+  status: 'active' | 'completed' | 'planned';
+  progress: number;
+  completedChapters: number;
+  totalChapters: number;
+  nextSession: string;
+  overview: string;
+  outline: CourseOutlineItem[];
+  keyResources: CourseResource[];
+  upcomingTasks: CourseTask[];
+}
+
+const initialCourses: Course[] = [
+  {
+    id: 'mue-0501',
+    title: 'MUE #0501 · 数模协同',
+    subtitle: 'STM32F407 ECH 调参与实验记录',
+    instructor: '导师：Evelyn 郑',
+    tags: ['控制', '嵌入式', '实验'],
+    status: 'active',
+    progress: 62,
+    completedChapters: 5,
+    totalChapters: 8,
+    nextSession: '周四 14:00 · 迭代评审',
+    overview:
+      '聚焦数模协同的控制策略优化，本周目标是验证新一版参数并固化实验记录，确保下周进入批量测试。',
+    outline: [
+      { title: '章节 1 · 控制模型回顾', duration: '45′', completed: true },
+      { title: '章节 2 · 驱动板接口梳理', duration: '40′', completed: true },
+      { title: '章节 3 · 参数扫频与结果分析', duration: '55′', completed: true },
+      { title: '章节 4 · 迭代方案设计', duration: '60′', completed: false },
+      { title: '章节 5 · 实验记录与复盘', duration: '40′', completed: false },
+    ],
+    keyResources: [
+      { title: '调参实验记录表（最新版）', type: '表格' },
+      { title: 'MATLAB 批量仿真脚本', type: '代码' },
+      { title: '控制策略评审纪要', type: '文档' },
+    ],
+    upcomingTasks: [
+      { title: '更新 PID 参数实验日志', due: '今日 · 21:30 截止', type: 'task' },
+      { title: '整理控制策略复盘 PPT', due: '周五 · 09:00', type: 'review' },
+    ],
+  },
+  {
+    id: 'mue-0502',
+    title: 'MUE #0502 · BHT70 仿真',
+    subtitle: '高频 Buck 拓扑失效模式分析',
+    instructor: '导师：陈工',
+    tags: ['仿真', '功率', '验证'],
+    status: 'active',
+    progress: 48,
+    completedChapters: 4,
+    totalChapters: 9,
+    nextSession: '周三 10:00 · 模型联调',
+    overview: '搭建 BHT70 高频仿真场景，验证不同磁性件参数对效率的影响，并输出仿真报告。',
+    outline: [
+      { title: '章节 1 · Buck 基础回顾', duration: '30′', completed: true },
+      { title: '章节 2 · 仿真环境准备', duration: '35′', completed: true },
+      { title: '章节 3 · 关键参数扫描', duration: '55′', completed: false },
+      { title: '章节 4 · 故障模式注入', duration: '45′', completed: false },
+      { title: '章节 5 · 数据整理与结论', duration: '40′', completed: false },
+    ],
+    keyResources: [
+      { title: 'PSIM 模板项目包', type: '工程' },
+      { title: '磁性件损耗模型 V2', type: '文档' },
+    ],
+    upcomingTasks: [
+      { title: '补充 200kHz 工况仿真截图', due: '明日 · 18:00', type: 'task' },
+      { title: '与电源设计团队同步评审', due: '周四 · 15:30', type: 'review' },
+    ],
+  },
+  {
+    id: 'mue-0503',
+    title: 'MUE #0503 · 知识资产沉淀',
+    subtitle: '资料库分支结构梳理与标签体系搭建',
+    instructor: '主持：技共学习台面',
+    tags: ['知识库', '结构化', '沉淀'],
+    status: 'planned',
+    progress: 15,
+    completedChapters: 1,
+    totalChapters: 6,
+    nextSession: '下周一 09:30 · 工作坊',
+    overview: '围绕知识积木树，搭建统一的标签和分支体系，便于跨项目检索复用。',
+    outline: [
+      { title: '章节 1 · 现状盘点', duration: '30′', completed: true },
+      { title: '章节 2 · 标签方案共创', duration: '50′', completed: false },
+      { title: '章节 3 · 分支映射草拟', duration: '45′', completed: false },
+      { title: '章节 4 · 工具链联动', duration: '40′', completed: false },
+    ],
+    keyResources: [
+      { title: '资料库现状盘点表', type: '表格' },
+      { title: '知识树结构草案', type: '白板' },
+    ],
+    upcomingTasks: [
+      { title: '邀请核心成员参与标签共创', due: '本周 · 发送邀请', type: 'task' },
+    ],
+  },
+  {
+    id: 'mue-0408',
+    title: 'MUE #0408 · Buck 200kHz 设计',
+    subtitle: '硬件版图确认与投板准备',
+    instructor: '导师：胡工',
+    tags: ['硬件', '版图', '验证'],
+    status: 'completed',
+    progress: 100,
+    completedChapters: 7,
+    totalChapters: 7,
+    nextSession: '已结项 · 待归档',
+    overview: '完成 Buck 200kHz 设计的版图确认与物料核对，等待最终投板。',
+    outline: [
+      { title: '章节 1 · 规格确认', duration: '30′', completed: true },
+      { title: '章节 2 · 原理图校审', duration: '45′', completed: true },
+      { title: '章节 3 · 版图走查', duration: '60′', completed: true },
+      { title: '章节 4 · BOM 核对', duration: '40′', completed: true },
+      { title: '章节 5 · 风险清单', duration: '30′', completed: true },
+    ],
+    keyResources: [
+      { title: '版图走查记录', type: '文档' },
+      { title: '风险清单 Checklist', type: '表格' },
+    ],
+    upcomingTasks: [
+      { title: '整理归档资料', due: '完成 · 等待上传', type: 'review' },
+    ],
+  },
+];
+
+const statusLabels: Record<Course['status'], string> = {
+  active: '进行中',
+  completed: '已完成',
+  planned: '规划中',
+};
+
+function CoursesPage() {
+  const [searchValue, setSearchValue] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'all' | Course['status']>('all');
+  const [selectedCourseId, setSelectedCourseId] = useState<string | null>(initialCourses[0]?.id ?? null);
+
+  const filteredCourses = useMemo(() => {
+    return initialCourses.filter((course) => {
+      const matchStatus = statusFilter === 'all' || course.status === statusFilter;
+      const matchKeyword = searchValue
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean)
+        .every((keyword) =>
+          [course.title, course.subtitle, course.tags.join(' '), course.instructor]
+            .join(' ')
+            .toLowerCase()
+            .includes(keyword),
+        );
+      return matchStatus && matchKeyword;
+    });
+  }, [searchValue, statusFilter]);
+
+  const selectedCourse = useMemo(
+    () => filteredCourses.find((course) => course.id === selectedCourseId) ?? filteredCourses[0] ?? null,
+    [filteredCourses, selectedCourseId],
+  );
+
+  useEffect(() => {
+    if (selectedCourse && selectedCourse.id !== selectedCourseId) {
+      setSelectedCourseId(selectedCourse.id);
+    }
+    if (!selectedCourse && filteredCourses.length === 0) {
+      setSelectedCourseId(null);
+    }
+  }, [filteredCourses, selectedCourse, selectedCourseId]);
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(event.target.value);
+  };
+
+  const handleStatusChange = (nextStatus: 'all' | Course['status']) => {
+    setStatusFilter(nextStatus);
+  };
+
+  return (
+    <div className="courses-layout">
+      <section className="card section courses-list">
+        <div className="section-header">
+          <div className="section-title">
+            <span className="capsule">课程总览</span>
+            <h2>学习路径</h2>
+          </div>
+        </div>
+        <div className="courses-filter-bar">
+          <input
+            type="search"
+            value={searchValue}
+            onChange={handleSearchChange}
+            placeholder="搜索课程、标签或导师"
+            className="search-field"
+            aria-label="搜索课程"
+          />
+          <div className="status-filter" role="group" aria-label="课程状态筛选">
+            {[
+              { value: 'all' as const, label: '全部' },
+              { value: 'active' as const, label: '进行中' },
+              { value: 'planned' as const, label: '规划中' },
+              { value: 'completed' as const, label: '已完成' },
+            ].map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={`chip-button${statusFilter === option.value ? ' primary' : ''}`}
+                onClick={() => handleStatusChange(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="courses-list-body">
+          {filteredCourses.length === 0 ? (
+            <div className="empty-state compact">
+              <Sparkles aria-hidden="true" />
+              <p>没有符合筛选条件的课程，试试调整搜索关键词或状态筛选。</p>
+            </div>
+          ) : (
+            <ul className="course-cards" role="list">
+              {filteredCourses.map((course) => (
+                <li key={course.id}>
+                  <button
+                    type="button"
+                    className={`course-card${selectedCourse?.id === course.id ? ' is-active' : ''}`}
+                    onClick={() => setSelectedCourseId(course.id)}
+                  >
+                    <div className="course-card-header">
+                      <div>
+                        <h3>{course.title}</h3>
+                        <p>{course.subtitle}</p>
+                      </div>
+                      <span className={`status-badge status-${course.status}`}>{statusLabels[course.status]}</span>
+                    </div>
+                    <div className="course-card-progress">
+                      <div className="progress-bar">
+                        <div className="progress-fill" style={{ width: `${course.progress}%` }} />
+                      </div>
+                      <span>{course.completedChapters}/{course.totalChapters} 章节</span>
+                    </div>
+                    <div className="tag-row">
+                      {course.tags.map((tag) => (
+                        <span className="tag" key={tag}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="course-card-meta">
+                      <span>
+                        <CalendarDays aria-hidden="true" />
+                        {course.nextSession}
+                      </span>
+                      <span>
+                        <BookOpenCheck aria-hidden="true" />
+                        完成度 {course.progress}%
+                      </span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <section className="card section course-details">
+        <div className="section-header">
+          <div className="section-title">
+            <span className="capsule">课程详情</span>
+            <h2>{selectedCourse ? selectedCourse.title : '等待选择课程'}</h2>
+            {selectedCourse ? <p className="subtitle">{selectedCourse.subtitle}</p> : null}
+          </div>
+          {selectedCourse ? (
+            <div className="section-actions">
+              <button type="button" className="chip-button primary">
+                <PlayCircle aria-hidden="true" /> 开始学习
+              </button>
+              <button type="button" className="chip-button">
+                <CalendarDays aria-hidden="true" /> 安排日程
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        {selectedCourse ? (
+          <div className="course-detail-body">
+            <div className="course-detail-hero">
+              <div>
+                <p className="course-instructor">{selectedCourse.instructor}</p>
+                <p className="course-overview">{selectedCourse.overview}</p>
+              </div>
+              <div className="course-detail-progress">
+                <span className="status-badge status-pill">{statusLabels[selectedCourse.status]}</span>
+                <div className="progress-bar large">
+                  <div className="progress-fill" style={{ width: `${selectedCourse.progress}%` }} />
+                </div>
+                <p className="progress-label">已完成 {selectedCourse.completedChapters} / {selectedCourse.totalChapters} 章节</p>
+              </div>
+            </div>
+
+            <div className="course-outline">
+              <h3>
+                <Tag aria-hidden="true" /> 学习章节
+              </h3>
+              <ol>
+                {selectedCourse.outline.map((item) => (
+                  <li key={item.title} className={item.completed ? 'is-completed' : ''}>
+                    <div className="outline-title">
+                      <CheckCircle2 aria-hidden="true" />
+                      <span>{item.title}</span>
+                    </div>
+                    <span className="outline-duration">{item.duration}</span>
+                  </li>
+                ))}
+              </ol>
+            </div>
+
+            <div className="course-panels">
+              <div className="course-panel">
+                <h3>关键资源</h3>
+                <ul>
+                  {selectedCourse.keyResources.map((resource) => (
+                    <li key={resource.title}>
+                      <span className="resource-type">{resource.type}</span>
+                      <span className="resource-title">{resource.title}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="course-panel">
+                <h3>待跟进事项</h3>
+                <ul>
+                  {selectedCourse.upcomingTasks.map((task) => (
+                    <li key={task.title} className={`task-${task.type}`}>
+                      <span className="task-title">{task.title}</span>
+                      <span className="task-due">{task.due}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="empty-state compact">
+            <Sparkles aria-hidden="true" />
+            <p>从左侧选择一门课程，即可查看学习章节、资源与待跟进事项。</p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+export default CoursesPage;

--- a/src/pages/courses/courses.css
+++ b/src/pages/courses/courses.css
@@ -1,0 +1,330 @@
+.courses-layout {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.courses-list {
+  position: sticky;
+  top: 40px;
+  height: fit-content;
+}
+
+.courses-filter-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.search-field {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border);
+  background: rgba(255, 252, 248, 0.95);
+  font-size: 15px;
+  color: var(--ink-500);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-field:focus {
+  border-color: rgba(255, 195, 138, 0.7);
+  box-shadow: 0 0 0 4px rgba(255, 195, 138, 0.18);
+  outline: none;
+}
+
+.status-filter {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.courses-list-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.course-cards {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 14px;
+}
+
+.course-card {
+  width: 100%;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(50, 75, 92, 0.12);
+  background: rgba(255, 252, 248, 0.95);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  box-shadow: var(--glow-soft);
+}
+
+.course-card:hover,
+.course-card:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(255, 195, 138, 0.5);
+  box-shadow: var(--shadow-hover);
+}
+
+.course-card.is-active {
+  border-color: rgba(255, 195, 138, 0.7);
+  background: rgba(255, 243, 228, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(255, 195, 138, 0.4), var(--shadow);
+}
+
+.course-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.course-card-header h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+  color: var(--ink-600);
+}
+
+.course-card-header p {
+  margin: 0;
+  color: var(--ink-400);
+  font-size: 14px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+}
+
+.status-active {
+  background: rgba(55, 179, 107, 0.12);
+  color: var(--success-strong);
+  border-color: rgba(55, 179, 107, 0.24);
+}
+
+.status-planned {
+  background: rgba(246, 167, 35, 0.12);
+  color: var(--warning);
+  border-color: rgba(246, 167, 35, 0.24);
+}
+
+.status-completed {
+  background: rgba(50, 75, 92, 0.08);
+  color: var(--ink-500);
+  border-color: rgba(50, 75, 92, 0.18);
+}
+
+.status-pill {
+  font-size: 13px;
+  padding: 6px 14px;
+}
+
+.course-card-progress {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  color: var(--ink-400);
+  font-size: 13px;
+}
+
+.course-card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--ink-400);
+}
+
+.course-card-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.course-card-meta svg {
+  width: 16px;
+  height: 16px;
+}
+
+.course-detail-body {
+  display: grid;
+  gap: 28px;
+}
+
+.course-detail-hero {
+  display: grid;
+  grid-template-columns: 1fr 240px;
+  gap: 32px;
+}
+
+.course-instructor {
+  margin: 0 0 8px;
+  font-weight: 600;
+  color: var(--ink-500);
+}
+
+.course-overview {
+  margin: 0;
+  color: var(--ink-400);
+  line-height: 1.6;
+}
+
+.course-detail-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.progress-bar.large {
+  height: 12px;
+  width: 100%;
+}
+
+.course-outline {
+  background: rgba(255, 252, 248, 0.9);
+  border: 1px solid rgba(50, 75, 92, 0.1);
+  border-radius: 24px;
+  padding: 20px 24px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.65);
+}
+
+.course-outline h3 {
+  margin: 0 0 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  color: var(--ink-600);
+}
+
+.course-outline ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.course-outline li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(255, 243, 228, 0.5);
+  border: 1px solid rgba(255, 217, 168, 0.4);
+  color: var(--ink-500);
+}
+
+.course-outline li.is-completed {
+  background: rgba(55, 179, 107, 0.1);
+  border-color: rgba(55, 179, 107, 0.28);
+  color: var(--success-strong);
+}
+
+.outline-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.outline-title svg {
+  width: 18px;
+  height: 18px;
+}
+
+.outline-duration {
+  font-size: 12px;
+  color: var(--ink-300);
+}
+
+.course-panels {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.course-panel {
+  border: 1px solid rgba(50, 75, 92, 0.12);
+  border-radius: 22px;
+  background: rgba(255, 252, 248, 0.9);
+  padding: 20px 22px;
+  display: grid;
+  gap: 14px;
+}
+
+.course-panel h3 {
+  margin: 0;
+  font-size: 16px;
+  color: var(--ink-600);
+}
+
+.course-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.course-panel li {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--ink-500);
+}
+
+.resource-type {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(255, 231, 204, 0.6);
+  border: 1px solid rgba(255, 217, 168, 0.6);
+  font-size: 12px;
+  color: var(--ink-600);
+}
+
+.resource-title {
+  flex: 1;
+}
+
+.task-title {
+  font-weight: 600;
+}
+
+.task-due {
+  font-size: 12px;
+  color: var(--ink-300);
+}
+
+.course-panel li.task-review {
+  color: var(--warning);
+}
+
+.course-panel li.task-task {
+  color: var(--ink-500);
+}


### PR DESCRIPTION
## Summary
- move the courses page implementation into a dedicated folder with its own stylesheet and lightweight re-export wrapper
- add a scoped stylesheet import for the under-construction placeholder so it no longer depends on App.css
- trim App.css back to the shared styles while retaining navigation and notification tweaks to reduce future merge conflicts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da6ec9c064833281b2b39cc3c8304a